### PR TITLE
Add Clear logs button

### DIFF
--- a/lib/global/logger.dart
+++ b/lib/global/logger.dart
@@ -29,18 +29,57 @@ class _LogTabState extends State<LogTab> {
 
   @override
   Widget build(BuildContext context) {
-    return SelectableRegion(
-      selectionControls: materialTextSelectionControls,
-      focusNode: FocusNode(),
-      child: Scrollbar(
-        thumbVisibility: true,
-        trackVisibility: true,
-        thickness: 5,
-        radius: const Radius.circular(2.5),
-        controller: _logScrollController,
-        child: SingleChildScrollView(
-          controller: _logScrollController,
-          child: CPText(Provider.of<LogState>(context).appLog),
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          // mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Divider(thickness: 1.0),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'LOGS',
+                  style: Theme.of(context).textTheme.headline5,
+                ),
+                SizedBox(),
+                ElevatedButton(
+                  onPressed: () {
+                    Provider.of<LogState>(context, listen: false).clearLog();
+                  },
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('Clear Logs'),
+                      SizedBox(
+                        width: 5,
+                      ),
+                      Icon(
+                        Icons.delete,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            SelectableRegion(
+              selectionControls: materialTextSelectionControls,
+              focusNode: FocusNode(),
+              child: Scrollbar(
+                thumbVisibility: true,
+                trackVisibility: true,
+                thickness: 5,
+                radius: const Radius.circular(2.5),
+                controller: _logScrollController,
+                child: SingleChildScrollView(
+                  controller: _logScrollController,
+                  child: CPText(Provider.of<LogState>(context).appLog),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
BLEMAPP-62: Add clear button to clear logs

Clear Logs button added to logs section. When button is clicked, deletes the logs.

Tested on Android and IOS.

General view of the button:
![before_click_button](https://user-images.githubusercontent.com/44245503/212070505-5b71c69b-06e2-4fb3-9708-964999d9257c.jpg)

After clicking the button:
![after_click_button](https://user-images.githubusercontent.com/44245503/212070532-57c6acd3-72dd-41c0-ab6d-8338a3293715.jpg)
